### PR TITLE
client v2 allows to use an apiKey

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,6 @@
 name: 🔨 Build Test
 
 on:
-  push:
   pull_request:
   workflow_dispatch:
 
@@ -12,11 +11,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -25,3 +25,5 @@ jobs:
         run: |
             mkdir tmp;
             go test;
+        env: 
+          NVD_API_KEY: "${{ secrets.NVD_API_KEY }}"

--- a/cve_test.go
+++ b/cve_test.go
@@ -16,6 +16,7 @@ func TestFetchCVEv2(t *testing.T) {
 	if !ok {
 		t.Fatal("NVD API key not passed as environment variable")
 	}
+
 	cliv2 := NewClientV2(apiKey)
 	testCases := []string{"CVE-2019-1010218", "CVE-2022-0149"}
 

--- a/cve_test.go
+++ b/cve_test.go
@@ -12,7 +12,11 @@ import (
 )
 
 func TestFetchCVEv2(t *testing.T) {
-	cliv2 := NewClientV2(os.Getenv("NVD_API_KEY"))
+	apiKey, ok := os.LookupEnv("NVD_API_KEY")
+	if !ok {
+		t.Fatal("NVD API key not passed as environment variable")
+	}
+	cliv2 := NewClientV2(apiKey)
 	testCases := []string{"CVE-2019-1010218", "CVE-2022-0149"}
 
 	for _, cveId := range testCases {

--- a/cve_test.go
+++ b/cve_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFetchCVEv2(t *testing.T) {
-	cliv2 := NewClientV2()
+	cliv2 := NewClientV2(os.Getenv("NVD_API_KEY"))
 	testCases := []string{"CVE-2019-1010218", "CVE-2022-0149"}
 
 	for _, cveId := range testCases {

--- a/nvd.go
+++ b/nvd.go
@@ -11,6 +11,7 @@ type Client struct {
 
 type ClientV2 struct {
 	endpoint string
+	apiKey   string
 }
 
 func NewClient(baseDir string) (cl *Client, err error) {
@@ -31,8 +32,9 @@ func NewClient(baseDir string) (cl *Client, err error) {
 	}, nil
 }
 
-func NewClientV2() (cl *ClientV2) {
+func NewClientV2(apiKey string) (cl *ClientV2) {
 	return &ClientV2{
 		endpoint: "https://services.nvd.nist.gov/rest/json/cves/2.0",
+		apiKey:   apiKey,
 	}
 }


### PR DESCRIPTION
ClientV2 currently does not use an apiKey which means we can get blocked by NVD. An api key can be easily request here: https://nvd.nist.gov/developers/request-an-api-key

As a follow up  we should add an NVD apiKey as a github secret and  update the github actions in order to add `NVD_API_KEY` as an env variable in order to use the created github secret.